### PR TITLE
Version 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # JetBrains IDE files
 /.idea/
 
-# Local tsting
-/test.js
+# Local testing
+/test/integration/config.js
 
 # Logs
 logs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Tim K.
+Copyright (c) 2017 Timur Kuzhagaliyev <tim.kuzh@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,59 +15,19 @@ A Discord bot that replaces spoiler messages with GIFs that reveal content on ho
 
 ![Discord Spoiler Bot with multi-line comments](https://foxypanda-ghost.s3.amazonaws.com/2017/Feb/Spoiler_Bot_Multiple_Lines-1487991244852.gif)
 
-# Quick start
+# Documentation
+ 
+ Check [Discord Spoiler Bot Wiki](https://github.com/TimboKZ/discord-spoiler-bot/wiki) on GitHub for full documentation. See section below for the quick start guide.
 
-Add `discord-spoiler-bot` to your NPM project:
+### Quick start
 
-```shell
-$ npm install discord-spoiler-bot --save
-```
-
-This bot uses `node-canvas` so make sure to [install its prerequisites](https://github.com/Automattic/node-canvas#installation). Then, put this into your `index.js`:
-
-```javascript
-'use strict';
-
-const SpoilerBot = require('discord-spoiler-bot');
-const token = 'your_secret_token';
-
-let bot = new SpoilerBot({token});
-bot.connect();
-```
-
-Run the bot:
-
-```shell
-$ node index.js
-```
-
-To create hidden spoilers, send a message of the following format: `<topic>:spoiler:<content>`, e.g.:
-
-```
-FMA:spoiler:Elric brothers are alchemists!
-```
-
-# Installation
-
-Make sure you have [Node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) installed. This bot was tested with Node v6+ so if you experience any issues, try upgrading your Node.js.
-
-First, you'll have to create a npm project and customise details as appropriate:
-
-```shell
-$ npm init
-```
-
-This bot uses [node-canvas](https://github.com/Automattic/node-canvas) to generate GIFs, so make sure you install the prerequisites mentioned in [its installation section](https://github.com/Automattic/node-canvas#installation).
-
-Then, you'll need to install `discord-spoiler-bot` and save it as a dependency:
+If you know what you're doing, you can jump right in. First, make sure you have [all prerequisites for `node-canvas` installed](https://github.com/Automattic/node-canvas#installation). Then add Discord Spoiler Bot to your npm project:
 
 ```shell
 $ npm install discord-spoiler-bot --save
 ```
 
-# Basic usage
-
-First of all, you'll need to obtain a secret token for your bot. The steps you need to take to do this [are described here](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token). Make sure to give the bot enough permissions to post messages and delete messages of other users. Once you have your token, you can begin using Discord Spoiler Bot! Create a file called `index.js` and put the following inside:
+Now get a secret token for your bot and make sure the bot has permission to read, write and delete messages as well as upload files. Create a file called `index.js` and put the following inside:
 
 ```javascript
 'use strict';
@@ -82,54 +42,19 @@ let bot = new SpoilerBot(config);
 bot.connect();
 ```
 
-Use the following command to start the bot:
+Launch your bot using Node.js:
 
 ```shell
 $ node index.js
 ```
 
-Now you should be able to send messages of the format `<topic>:spoiler:<content>` to create spoiler GIFs. Read sections below to see how you can change the format of spoiler messages.
+And you're done! Write messages of format `<topic>:spoiler:<content>` to mark your own messages as spoilers, e.g.:
 
-# Advanced configuration
-
-As seen above, you have to create a config to initialise `SpoilerBot`. Below you can find the config properties you can set.
-
-| Property               | Default value | Description                                                                                                                                                                                                                |
-|------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `token` **[required]** | None          | Secret token of your Discord bot                                                                                                                                                                                           |
-| `maxLines`             | 6             | Maximum amount of lines that spoiler content can span over.                                                                                                                                                                |
-| `include`              | None          | Array of strings, where each string represents an ID of a channel. When this property is set, bot will only listen to the specified channels. Cannot be used together with `exclude`.                                      |
-| `exclude`              | None          | Array of strings, where each string represents an ID of a channel. When this property is set, bot will listen to all channels but the one specified in this array. Cannot be used together with `include`.                 |
-| `extractSpoiler`       | None          | Function that takes a [Discord.js `Message`](https://discord.js.org/#/docs/main/stable/class/Message) object and returns a `Spoiler` object if the message contains a spoiler or `null` if it does not. See example below. |
-
-### Config example
-
-Here's a sample config with some comments:
-
-```javascript
-let config = {
-    token: 'you_secret_token_here',
-    
-    // Allow 20 lines in a spoiler, results in some big GIFs
-    maxLines: 20,
-    
-    // Only listen to 2 specific channels
-    include: [
-        '241271400869003265',
-        '241512070854606848'
-    ],
-    
-    // Mark messages that begin with `spoiler:` as spoilers.
-    // Sets `Some Topic` as the topic for all spoilers and
-    // passes original message content as spoiler content.
-    extractSpoiler: (message) => {
-        if (!message.content.match(/^spoiler:/gi)) {
-            return null;
-        }
-        return new SpoilerBot.Spoiler(message.author, 'Some Topic', message.content);
-    }
-};
 ```
+FMA:spoiler:Elric brothers are alchemists!
+```
+
+To mark someone else's messages, use `<message-id>:spoils:<topic>`, but you will have to configure permissions first. See [Configuration](https://github.com/TimboKZ/discord-spoiler-bot/wiki/Configuration) section.
 
 # Reporting bugs
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "discord-spoiler-bot",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A bot for Discord that replaces spoiler messages with GIFs that reveal content on hover.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive ./test/",
+    "test": "mocha --recursive ./test/mocha/",
     "lint": "eslint ./src/ ./test/"
   },
   "repository": {
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/TimboKZ/discord-spoiler-bot#readme",
   "dependencies": {
     "canvas": "^1.6.3",
+    "discord.io": "^2.4.2",
     "discord.js": "^11.0.0",
     "gifencoder": "^1.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-spoiler-bot",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A bot for Discord that replaces spoiler messages with GIFs that reveal content on hover.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-spoiler-bot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A bot for Discord that replaces spoiler messages with GIFs that reveal content on hover.",
   "main": "index.js",
   "scripts": {

--- a/src/DiscordClient.js
+++ b/src/DiscordClient.js
@@ -1,0 +1,137 @@
+/**
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2017
+ * @license MIT
+ */
+
+const DiscordJS = require('discord.js');
+const DiscordIO = require('discord.io');
+
+const DISCORD_JS = 'discord.js';
+const DISCORD_IO = 'discord.io';
+
+class DiscordMessage {
+
+    /**
+     * @param {string} id
+     * @param {string} channelId
+     * @param {string} authorId
+     * @param {string} content
+     */
+    constructor(id, channelId, authorId, content) {
+        this.id = id;
+        this.channelId = channelId;
+        this.authorId = authorId;
+        this.content = content;
+    }
+
+}
+
+class DiscordClient {
+
+    /**
+     * @param {Object} config
+     * @param {DiscordJS.Client|DiscordIO.Client} config.client
+     * @param {string} config.token
+     */
+    constructor(config) {
+        let client = config.client;
+        if (config.token) {
+            client = new DiscordJS.Client();
+            client.login(config.token);
+        }
+        this.type = client instanceof DiscordJS.Client ? DISCORD_JS : DISCORD_IO;
+        this.client = client;
+    }
+
+    /**
+     * @callback messageListener
+     * @param {DiscordMessage} message
+     */
+
+    /**
+     * @param {messageListener} listener
+     */
+    addMessageListener(listener) {
+        if (this.type === DISCORD_JS) {
+            this.client.on('message', DiscordClient.processDiscordJSMessage.bind(null, listener));
+        } else {
+            this.client.on('message', DiscordClient.processDiscordIOMessage.bind(null, listener));
+        }
+    }
+
+    /**
+     * @param {messageListener} listener
+     * @param {DiscordJS.Message} message
+     */
+    static processDiscordJSMessage(listener, message) {
+        listener(new DiscordMessage(
+            message.id,
+            message.channel.id,
+            message.author.id,
+            message.content
+        ));
+    }
+
+    /**
+     *
+     * @param {messageListener} listener
+     * @param {string} user
+     * @param {string} userID
+     * @param {string} channelID
+     * @param {string} message
+     * @param {Object} event
+     */
+    static processDiscordIOMessage(listener, user, userID, channelID, message, event) {
+        listener(new DiscordMessage(
+            event.d.id,
+            channelID,
+            userID,
+            message
+        ));
+    }
+
+    /**
+     * @param {DiscordMessage} message
+     * @param {function} done
+     */
+    deleteMessage(message, done) {
+        if (this.type === DISCORD_JS) {
+            this.client.channels.get(message.channelId).fetchMessage(message.id).then((message) => {
+                message.delete();
+                done();
+            });
+        } else {
+            this.client.deleteMessage({
+                channelID: message.channelId,
+                messageIDs: message.id
+            }, done);
+        }
+    }
+
+    /**
+     * @param {string} channelId
+     * @param {string} filePath
+     * @param {string} fileName
+     * @param {string} content
+     * @param {function} done
+     */
+    sendFile(channelId, filePath, fileName, content, done) {
+        if (this.type === DISCORD_JS) {
+            this.client.channels.get(channelId).sendFile(filePath, fileName, content).then(() => done());
+        } else {
+            let options = {
+                to: channelId,
+                file: filePath,
+                filename: fileName,
+                message: content,
+            };
+            this.client.uploadFile(options, done);
+        }
+    }
+
+}
+
+DiscordClient.DiscordMessage = DiscordMessage;
+
+module.exports = DiscordClient;

--- a/src/DiscordClient.js
+++ b/src/DiscordClient.js
@@ -1,5 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */

--- a/src/GifGenerator.js
+++ b/src/GifGenerator.js
@@ -160,7 +160,8 @@ class GifGenerator {
         if(SOURCE_SANS_PRO !== null) {
             context.addFont(SOURCE_SANS_PRO);
         }
-        context.font = '13px aSourceSansPro';
+        let fontName = SOURCE_SANS_PRO !== null ? 'aSourceSansPro' : '"Lucida Sans Unicode"';
+        context.font = `13px ${fontName}`;
         return context;
     }
 

--- a/src/GifGenerator.js
+++ b/src/GifGenerator.js
@@ -1,6 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
- * @see https://github.com/TimboKZ/discord-spoiler-bot
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */

--- a/src/GifGenerator.js
+++ b/src/GifGenerator.js
@@ -42,7 +42,7 @@ class GifGenerator {
      * @return {string}
      */
     static createSpoilerGif(spoiler, maxLines, done) {
-        let hash = `${spoiler.author.id}-${(new Date()).getTime()}`;
+        let hash = `${spoiler.authorId}-${(new Date()).getTime()}`;
         let gifPath = path.join(GIF_PATH, `${hash}.gif`);
         GifGenerator.createGif(spoiler, maxLines, gifPath, done);
         return gifPath;

--- a/src/SpoilerBot.js
+++ b/src/SpoilerBot.js
@@ -1,6 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
- * @see https://github.com/TimboKZ/discord-spoiler-bot
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */
@@ -34,8 +34,10 @@ class SpoilerBot {
 
     /**
      * @callback extractSpoiler
-     * @param {Discord.Message} message
-     * @return {Spoiler}
+     * @param {DiscordMessage} message
+     * @param {fetchMessage} fetchMessage
+     * @param {checkMarkPermission} checkMarkPermission
+     * @param {spoilerCallback} callback
      */
 
     /**

--- a/test/integration/config.example.js
+++ b/test/integration/config.example.js
@@ -6,6 +6,12 @@
 
 module.exports = {
     token: 'your_bot_token_here',
+    markUserIds: [
+        '242276581039538178'
+    ],
+    markRoleIds: [
+        '285235614805262339',
+    ],
     maxLines: 6,
     exclude: [],
 

--- a/test/integration/config.example.js
+++ b/test/integration/config.example.js
@@ -8,6 +8,7 @@ module.exports = {
     token: 'your_bot_token_here',
     maxLines: 6,
     exclude: [],
+
     extractSpoiler: (message) => {
         if (!message.content.match(/^spoiler:/gi)) {
             return null;

--- a/test/integration/config.example.js
+++ b/test/integration/config.example.js
@@ -1,0 +1,17 @@
+/**
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2017
+ * @license MIT
+ */
+
+module.exports = {
+    token: 'your_bot_token_here',
+    maxLines: 6,
+    exclude: [],
+    extractSpoiler: (message) => {
+        if (!message.content.match(/^spoiler:/gi)) {
+            return null;
+        }
+        return new SpoilerBot.Spoiler(message.author, 'Some Topic', message.content);
+    }
+};

--- a/test/integration/launch-discord-io.js
+++ b/test/integration/launch-discord-io.js
@@ -1,0 +1,20 @@
+/**
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2017
+ * @license MIT
+ */
+
+const Discord = require('discord.io');
+const SpoilerBot = require('../../src/SpoilerBot');
+const config = require('./config');
+
+let client = new Discord.Client({
+    autorun: true,
+    token: config.token
+});
+
+delete config.token;
+config.client = client;
+
+let bot = new SpoilerBot(config);
+bot.connect();

--- a/test/integration/launch-discord-io.js
+++ b/test/integration/launch-discord-io.js
@@ -1,5 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */

--- a/test/integration/launch-discord-js.js
+++ b/test/integration/launch-discord-js.js
@@ -1,0 +1,18 @@
+/**
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2017
+ * @license MIT
+ */
+
+const Discord = require('discord.js');
+const SpoilerBot = require('../../src/SpoilerBot');
+const config = require('./config');
+
+let client = new Discord.Client();
+client.login(config.token);
+
+delete config.token;
+config.client = client;
+
+let bot = new SpoilerBot(config);
+bot.connect();

--- a/test/integration/launch-discord-js.js
+++ b/test/integration/launch-discord-js.js
@@ -1,5 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */

--- a/test/integration/launch-standalone.js
+++ b/test/integration/launch-standalone.js
@@ -1,0 +1,11 @@
+/**
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2017
+ * @license MIT
+ */
+
+const SpoilerBot = require('../../src/SpoilerBot');
+const config = require('./config');
+
+let bot = new SpoilerBot(config);
+bot.connect();

--- a/test/integration/launch-standalone.js
+++ b/test/integration/launch-standalone.js
@@ -1,5 +1,6 @@
 /**
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @see https://github.com/TimboKZ/discord-spoiler-bot/wiki
  * @copyright 2017
  * @license MIT
  */

--- a/test/mocha/ConfigTest.js
+++ b/test/mocha/ConfigTest.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const SpoilerBot = require('./../src/SpoilerBot');
+const SpoilerBot = require('./../../src/SpoilerBot');
 const {describe, it} = require('mocha');
 const assert = require('chai').assert;
 

--- a/test/mocha/GifGeneratorTest.js
+++ b/test/mocha/GifGeneratorTest.js
@@ -7,8 +7,8 @@
 
 'use strict';
 
-const GifGenerator = require('./../src/GifGenerator');
-const SpoilerBot = require('./../src/SpoilerBot');
+const GifGenerator = require('./../../src/GifGenerator');
+const SpoilerBot = require('./../../src/SpoilerBot');
 const {describe, it} = require('mocha');
 const assert = require('chai').assert;
 const fs = require('fs');


### PR DESCRIPTION
* Bump version to `2.0.0`.
* Add support for external bot instances, see [wiki](https://github.com/TimboKZ/discord-spoiler-bot/wiki) for more info.
* Users can now mark someone else's messages as spoilers using `<message-id>:spoils:<topic>` format, given right permissions have been specified using the config.