### PR TITLE
Add line break support

### DIFF
--- a/src/GifGenerator.js
+++ b/src/GifGenerator.js
@@ -81,21 +81,25 @@ class GifGenerator {
      * @return {string[]}
      */
     static breakIntoLines(text, context, maxLines) {
-        let words = text.split(' ');
         let lines = [];
-        let line = '';
-        for (let i = 0; i < words.length; i++) {
-            if (line !== '') line += ' ';
-            let word = words[i];
-            let max = Math.max(context.measureText(line).width, context.measureText(line + word).width);
-            if (max > LINE_WIDTH) {
-                lines.push(line);
-                line = '';
+        let linesBreak = text.split('\n');
+        for (let j = 0; j < linesBreak.length; j++) {
+            let line = '';
+            let words = linesBreak[j].split(' ');
+            for (let i = 0; i < words.length; i++) {
+                if (line !== '') line += ' ';
+                let word = words[i];
+                let max = Math.max(context.measureText(line).width, context.measureText(line + word).width);
+                if (max > LINE_WIDTH) {
+                    lines.push(line);
+                    line = '';
+                }
+                line += word;
             }
-            line += word;
-        }
-        if(line !== '' || lines.length === 0) {
-            lines.push(line);
+            if(line !== '' || lines.length === 0) {
+                lines.push(line);
+            }
+
         }
         if(lines.length > maxLines) {
             lines = lines.slice(0, maxLines);


### PR DESCRIPTION
Hello,

There is a bug when user input have a line break.

Before:
![image](https://cloud.githubusercontent.com/assets/10158198/24588007/9ae947be-17c0-11e7-9c45-cc1f428fe642.png)

After:
![image](https://cloud.githubusercontent.com/assets/10158198/24588021/d3656e24-17c0-11e7-9c9d-ccbd5c05b016.png)

By the way, very nice work ! Thank you.

PS: I am working on a Docker container here: [https://github.com/Aeryax/docker-spoilerbot](https://github.com/Aeryax/docker-spoilerbot)
PS²: Sorry, I don't have requirements to install node-canvas so I can't run npm run test and lint. I hope it's ok.