### PR TITLE
Line breaking tests, newline char fix, deprecated warning fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Please create an issue thread [here](https://github.com/TimboKZ/discord-spoiler-
 
 I believe this bot is feature-complete, and from now on will most likely only fix bugs. Before adding a new feature to this bot and creating a pull request, make sure said feature makes sense in the context of Discord Spoiler Bot.
 
-Make sure `npm test` and `npm run lint` return no errors before making a pull request, otherwise I might reject it.
+Make sure `npm test` and `npm run lint` return no errors before making a pull request, otherwise I might reject it. `npm run test-no-delete` is available for your convenience, running this command will make sure that GIFs produced during testing are not removed so you can inspect them for any artifacts.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --recursive ./test/mocha/",
+    "test-no-delete": "env NO_DELETE=true mocha --recursive ./test/mocha/",
     "lint": "eslint ./src/ ./test/"
   },
   "repository": {
@@ -37,6 +38,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.16.1",
+    "lorem-ipsum": "^1.0.3",
     "mocha": "^3.2.0"
   }
 }

--- a/src/GifGenerator.js
+++ b/src/GifGenerator.js
@@ -81,21 +81,25 @@ class GifGenerator {
      * @return {string[]}
      */
     static breakIntoLines(text, context, maxLines) {
-        let words = text.split(' ');
         let lines = [];
-        let line = '';
-        for (let i = 0; i < words.length; i++) {
-            if (line !== '') line += ' ';
-            let word = words[i];
-            let max = Math.max(context.measureText(line).width, context.measureText(line + word).width);
-            if (max > LINE_WIDTH) {
-                lines.push(line);
-                line = '';
+        let linesBreak = text.split('\n');
+        for (let j = 0; j < linesBreak.length; j++) {
+            let line = '';
+            let words = linesBreak[j].split(' ');
+            for (let i = 0; i < words.length; i++) {
+                if (line !== '') line += ' ';
+                let word = words[i];
+                let max = Math.max(context.measureText(line).width, context.measureText(line + word).width);
+                if (max > LINE_WIDTH) {
+                    lines.push(line);
+                    line = '';
+                }
+                line += word;
             }
-            line += word;
-        }
-        if(line !== '' || lines.length === 0) {
-            lines.push(line);
+            if(line !== '' || lines.length === 0) {
+                lines.push(line);
+            }
+
         }
         if(lines.length > maxLines) {
             lines = lines.slice(0, maxLines);

--- a/src/SpoilerBot.js
+++ b/src/SpoilerBot.js
@@ -220,7 +220,7 @@ class SpoilerBot {
         let maxLines = this.config.maxLines ? this.config.maxLines : DEFAULT_MAX_LINES;
         GifGenerator.createSpoilerGif(spoiler, maxLines, filePath => {
             this.client.sendFile(spoiler.message.channelId, filePath, 'spoiler.gif', messageContent, () => {
-                fs.unlink(filePath);
+                fs.unlink(filePath, (err) => err ? console.error(`Could not remove GIF: ${err}`) : null);
             });
         });
     }

--- a/test/mocha/GifGeneratorTest.js
+++ b/test/mocha/GifGeneratorTest.js
@@ -7,21 +7,53 @@
 
 'use strict';
 
+const fs = require('fs');
+const lipsum = require('lorem-ipsum');
+const assert = require('chai').assert;
+const {describe, it} = require('mocha');
 const GifGenerator = require('./../../src/GifGenerator');
 const SpoilerBot = require('./../../src/SpoilerBot');
-const {describe, it} = require('mocha');
-const assert = require('chai').assert;
-const fs = require('fs');
+
+const createGif = (content, done) => {
+    let spoiler = new SpoilerBot.Spoiler({id: 'test'}, 'Test Topic', content);
+    GifGenerator.createSpoilerGif(spoiler, 6, (filePath) => {
+        assert.isTrue(fs.existsSync(filePath));
+        if (!process.env.NO_DELETE) {
+            fs.unlink(filePath, (err) => err ? console.error(`Could not remove GIF: ${err}`) : null);
+        }
+        done();
+    });
+};
+
+const context = GifGenerator.createCanvasContext(15);
+const countLines = (content, lineCount) => {
+    let lines = GifGenerator.breakIntoLines(content, context, lineCount);
+    assert.strictEqual(lines.length, lineCount);
+};
 
 describe('GifGenerator', () => {
     describe('#createSpoilerGif', () => {
         it('should create a GIF', (done) => {
-            let spoiler = new SpoilerBot.Spoiler({id: 'test'}, 'Test Topic', 'Test Content');
-            GifGenerator.createSpoilerGif(spoiler, 6, (filePath) => {
-                assert.isTrue(fs.existsSync(filePath));
-                fs.unlink(filePath);
-                done();
-            });
+            createGif('Test Content', done);
+        });
+        it('should properly create a multi-line GIF', (done) => {
+            createGif('First line \n Second line', done);
+        });
+    });
+    describe('#breakIntoLines', () => {
+        it('should limit the amount of lines to the specified number', (done) => {
+            let content = lipsum({count: 20, units: 'sentences'});
+            countLines(content, 1);
+            countLines(content, 6);
+            countLines(content, 8);
+            countLines('Line 1\nLine 2\nLine 3', 1);
+            done();
+        });
+        it('should properly parse newline characters', (done) => {
+            countLines('Line 1', 1);
+            countLines('Line 1\nLine 2', 2);
+            countLines('Line 1\nLine 2\nLine 3', 3);
+            done();
         });
     });
 });


### PR DESCRIPTION
* Added tests for correct line-breaking and parsing of newline characters.
* Merged solution for incorrect newline parsing from #10.
* Fixed deprecated warning being printed to console by adding a callback to `unlink()`.